### PR TITLE
Добавлен выбор языка в настройках

### DIFF
--- a/HuntersCompanion/HunterCompanionApp.swift
+++ b/HuntersCompanion/HunterCompanionApp.swift
@@ -4,18 +4,19 @@ import SwiftUI
 @main
 struct HunterCompanionApp: App {
     @StateObject private var settingsManager = SettingsManager()
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(settingsManager)
+                .environment(\.locale, .init(identifier: settingsManager.currentLanguage.rawValue))
         }
     }
 }
 
 // MARK: - Settings Manager
 class SettingsManager: ObservableObject {
-    @Published var currentLanguage: String = "en"
+    @Published var currentLanguage: AppLanguage = .en
     @Published var selectedTheme: AppTheme = .nature
     
     init() {
@@ -23,7 +24,12 @@ class SettingsManager: ObservableObject {
     }
     
     private func loadSettings() {
-        currentLanguage = UserDefaults.standard.string(forKey: "app_language") ?? "en"
+        if let langRaw = UserDefaults.standard.string(forKey: "app_language"),
+           let lang = AppLanguage(rawValue: langRaw) {
+            currentLanguage = lang
+        } else {
+            currentLanguage = .en
+        }
         if let themeRaw = UserDefaults.standard.string(forKey: "app_theme"),
            let theme = AppTheme(rawValue: themeRaw) {
             selectedTheme = theme
@@ -31,8 +37,20 @@ class SettingsManager: ObservableObject {
     }
     
     func saveSettings() {
-        UserDefaults.standard.set(currentLanguage, forKey: "app_language")
+        UserDefaults.standard.set(currentLanguage.rawValue, forKey: "app_language")
         UserDefaults.standard.set(selectedTheme.rawValue, forKey: "app_theme")
+    }
+}
+
+enum AppLanguage: String, CaseIterable {
+    case en
+    case es
+
+    var localizedName: LocalizedStringKey {
+        switch self {
+        case .en: return "language_en"
+        case .es: return "language_es"
+        }
     }
 }
 

--- a/HuntersCompanion/OtherViews.swift
+++ b/HuntersCompanion/OtherViews.swift
@@ -733,6 +733,14 @@ struct SettingsView: View {
                         }
                     }
                 }
+
+                Section("language_settings") {
+                    Picker("app_language", selection: $settingsManager.currentLanguage) {
+                        ForEach(AppLanguage.allCases, id: \.self) { language in
+                            Text(language.localizedName).tag(language)
+                        }
+                    }
+                }
                 
                 Section("about_app") {
                     HStack {

--- a/HuntersCompanion/en.lproj/Localizable.strings
+++ b/HuntersCompanion/en.lproj/Localizable.strings
@@ -411,3 +411,5 @@
 "theme_winter" = "Winter";
 
 "select_language" = "Select Language";
+"language_en" = "English";
+"language_es" = "Spanish";

--- a/HuntersCompanion/es.lproj/Localizable.strings
+++ b/HuntersCompanion/es.lproj/Localizable.strings
@@ -411,3 +411,5 @@
 "theme_winter" = "Invierno";
 
 "select_language" = "Seleccionar Idioma";
+"language_en" = "Inglés";
+"language_es" = "Español";


### PR DESCRIPTION
## Summary
- add language picker in SettingsView
- support AppLanguage in SettingsManager
- persist and load language from settings
- localize language names

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884ddaa839c832081e07687dc561ff3