### PR TITLE
Add SwiftData models and view models

### DIFF
--- a/HuntersCompanion/ContentView.swift
+++ b/HuntersCompanion/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @EnvironmentObject var settingsManager: SettingsManager
     @Environment(\.colorSchemeContrast) var systemContrast
     @State private var selectedTab = 0
-    @State private var showOnboarding = !UserDefaults.standard.bool(forKey: "has_seen_onboarding")
+    @State private var showOnboarding = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -49,6 +49,9 @@ struct ContentView: View {
         .sheet(isPresented: $showOnboarding) {
             OnboardingView(show: $showOnboarding)
                 .environmentObject(settingsManager)
+        }
+        .onAppear {
+            showOnboarding = !settingsManager.hasSeenOnboarding
         }
     }
 }

--- a/HuntersCompanion/Models.swift
+++ b/HuntersCompanion/Models.swift
@@ -1,29 +1,46 @@
 // Models.swift (ИСПРАВЛЕННАЯ ВЕРСИЯ)
 import SwiftUI
+import SwiftData
 
 // MARK: - Animal Model
-struct Animal: Identifiable, Hashable {
-    let id = UUID()
-    let name: String // Изменено с LocalizedStringKey на String
-    let scientificName: String
-    let icon: String
-    let description: String // Изменено с LocalizedStringKey на String
-    let habitat: String // Изменено с LocalizedStringKey на String
-    let bestSeasons: [Season]
-    let activityPattern: ActivityPattern
-    let recommendedBaits: [String]
-    let difficulty: DifficultyLevel
-    let facts: [String] // Изменено с LocalizedStringKey на String
-    
-    // Equatable implementation
-    static func == (lhs: Animal, rhs: Animal) -> Bool {
-        return lhs.id == rhs.id
+@Model
+final class Animal: Identifiable, Hashable {
+    @Attribute(.unique) var id: UUID
+    var name: String // Изменено с LocalizedStringKey на String
+    var scientificName: String
+    var icon: String
+    var description: String // Изменено с LocalizedStringKey на String
+    var habitat: String // Изменено с LocalizedStringKey на String
+    var bestSeasons: [Season]
+    var activityPattern: ActivityPattern
+    var recommendedBaits: [String]
+    var difficulty: DifficultyLevel
+    var facts: [String] // Изменено с LocalizedStringKey на String
+
+    init(id: UUID = UUID(),
+         name: String,
+         scientificName: String,
+         icon: String,
+         description: String,
+         habitat: String,
+         bestSeasons: [Season],
+         activityPattern: ActivityPattern,
+         recommendedBaits: [String],
+         difficulty: DifficultyLevel,
+         facts: [String]) {
+        self.id = id
+        self.name = name
+        self.scientificName = scientificName
+        self.icon = icon
+        self.description = description
+        self.habitat = habitat
+        self.bestSeasons = bestSeasons
+        self.activityPattern = activityPattern
+        self.recommendedBaits = recommendedBaits
+        self.difficulty = difficulty
+        self.facts = facts
     }
     
-    // Hashable implementation
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
     
     static let mockAnimals: [Animal] = [
         Animal(
@@ -205,16 +222,37 @@ enum DifficultyLevel: String, CaseIterable, Hashable {
 }
 
 // MARK: - Practice Model
-struct HuntingPractice: Identifiable {
-    let id = UUID()
-    let name: String // Изменено с LocalizedStringKey на String
-    let description: String // Изменено с LocalizedStringKey на String
-    let icon: String
-    let category: PracticeCategory
-    let duration: TimeInterval // in seconds
-    let difficulty: DifficultyLevel
-    let instructions: [String] // Изменено с LocalizedStringKey на String
-    let tips: [String] // Изменено с LocalizedStringKey на String
+@Model
+final class HuntingPractice: Identifiable {
+    @Attribute(.unique) var id: UUID
+    var name: String // Изменено с LocalizedStringKey на String
+    var description: String // Изменено с LocalizedStringKey на String
+    var icon: String
+    var category: PracticeCategory
+    var duration: TimeInterval // in seconds
+    var difficulty: DifficultyLevel
+    var instructions: [String] // Изменено с LocalizedStringKey на String
+    var tips: [String] // Изменено с LocalizedStringKey на String
+
+    init(id: UUID = UUID(),
+         name: String,
+         description: String,
+         icon: String,
+         category: PracticeCategory,
+         duration: TimeInterval,
+         difficulty: DifficultyLevel,
+         instructions: [String],
+         tips: [String]) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.icon = icon
+        self.category = category
+        self.duration = duration
+        self.difficulty = difficulty
+        self.instructions = instructions
+        self.tips = tips
+    }
     
     static let allPractices: [HuntingPractice] = [
         HuntingPractice(
@@ -302,15 +340,34 @@ enum PracticeCategory: String, CaseIterable {
 }
 
 // MARK: - Bait Model
-struct Bait: Identifiable {
-    let id = UUID()
-    let name: String
-    let icon: String
-    let description: String
-    let category: BaitCategory
-    let effectiveness: Int // 1-4 stars
-    let ingredients: [String]
-    let steps: [String]
+@Model
+final class Bait: Identifiable {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var icon: String
+    var description: String
+    var category: BaitCategory
+    var effectiveness: Int // 1-4 stars
+    var ingredients: [String]
+    var steps: [String]
+
+    init(id: UUID = UUID(),
+         name: String,
+         icon: String,
+         description: String,
+         category: BaitCategory,
+         effectiveness: Int,
+         ingredients: [String],
+         steps: [String]) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.description = description
+        self.category = category
+        self.effectiveness = effectiveness
+        self.ingredients = ingredients
+        self.steps = steps
+    }
 
     static let allBaits: [Bait] = [
         Bait(

--- a/HuntersCompanion/Models/AchievementEntity.swift
+++ b/HuntersCompanion/Models/AchievementEntity.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AchievementEntity {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var details: String
+    var unlocked: Bool
+
+    init(id: UUID = UUID(), title: String, details: String, unlocked: Bool = false) {
+        self.id = id
+        self.title = title
+        self.details = details
+        self.unlocked = unlocked
+    }
+}

--- a/HuntersCompanion/Models/AnimalEntity.swift
+++ b/HuntersCompanion/Models/AnimalEntity.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AnimalEntity {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var scientificName: String
+    var icon: String
+    var details: String
+    var habitat: String
+    var bestSeasons: [String]
+    var recommendedBaits: [String]
+    var difficulty: String
+    var facts: [String]
+
+    init(id: UUID = UUID(),
+         name: String,
+         scientificName: String,
+         icon: String,
+         details: String,
+         habitat: String,
+         bestSeasons: [String],
+         recommendedBaits: [String],
+         difficulty: String,
+         facts: [String]) {
+        self.id = id
+        self.name = name
+        self.scientificName = scientificName
+        self.icon = icon
+        self.details = details
+        self.habitat = habitat
+        self.bestSeasons = bestSeasons
+        self.recommendedBaits = recommendedBaits
+        self.difficulty = difficulty
+        self.facts = facts
+    }
+}

--- a/HuntersCompanion/Models/BaitEntity.swift
+++ b/HuntersCompanion/Models/BaitEntity.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+@Model
+final class BaitEntity {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var icon: String
+    var details: String
+    var category: String
+    var effectiveness: Int
+    var ingredients: [String]
+    var steps: [String]
+
+    init(id: UUID = UUID(),
+         name: String,
+         icon: String,
+         details: String,
+         category: String,
+         effectiveness: Int,
+         ingredients: [String],
+         steps: [String]) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.details = details
+        self.category = category
+        self.effectiveness = effectiveness
+        self.ingredients = ingredients
+        self.steps = steps
+    }
+}

--- a/HuntersCompanion/Models/LocationEntity.swift
+++ b/HuntersCompanion/Models/LocationEntity.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+@Model
+final class LocationEntity {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var latitude: Double
+    var longitude: Double
+
+    init(id: UUID = UUID(), name: String, latitude: Double, longitude: Double) {
+        self.id = id
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/HuntersCompanion/Models/PersistenceController.swift
+++ b/HuntersCompanion/Models/PersistenceController.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+enum PersistenceController {
+    static let shared: ModelContainer = {
+        let schema = Schema([
+            AnimalEntity.self,
+            BaitEntity.self,
+            UserProgressEntity.self,
+            LocationEntity.self,
+            AchievementEntity.self,
+            SettingsEntity.self
+        ])
+        let configuration = ModelConfiguration(schema: schema)
+        return try! ModelContainer(for: schema, configurations: [configuration])
+    }()
+}

--- a/HuntersCompanion/Models/SettingsEntity.swift
+++ b/HuntersCompanion/Models/SettingsEntity.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SettingsEntity {
+    @Attribute(.unique) var id: UUID
+    var language: String
+    var theme: String
+    var largeText: Bool
+    var highContrast: Bool
+    var hasSeenOnboarding: Bool
+
+    init(id: UUID = UUID(), language: String = "en", theme: String = "nature", largeText: Bool = false, highContrast: Bool = false, hasSeenOnboarding: Bool = false) {
+        self.id = id
+        self.language = language
+        self.theme = theme
+        self.largeText = largeText
+        self.highContrast = highContrast
+        self.hasSeenOnboarding = hasSeenOnboarding
+    }
+}

--- a/HuntersCompanion/Models/UserProgressEntity.swift
+++ b/HuntersCompanion/Models/UserProgressEntity.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftData
+
+@Model
+final class UserProgressEntity {
+    @Attribute(.unique) var id: UUID
+    var completedPracticeIds: [UUID]
+
+    init(id: UUID = UUID(), completedPracticeIds: [UUID] = []) {
+        self.id = id
+        self.completedPracticeIds = completedPracticeIds
+    }
+}

--- a/HuntersCompanion/OnboardingView.swift
+++ b/HuntersCompanion/OnboardingView.swift
@@ -23,7 +23,8 @@ struct OnboardingView: View {
             .accessibilityLabel(Text("sign_in_with_apple"))
 
             Button("get_started") {
-                UserDefaults.standard.set(true, forKey: "has_seen_onboarding")
+                settingsManager.hasSeenOnboarding = true
+                settingsManager.saveSettings()
                 show = false
             }
             .padding()

--- a/HuntersCompanion/SeasonsView.swift
+++ b/HuntersCompanion/SeasonsView.swift
@@ -1,9 +1,11 @@
 // SeasonsView.swift
 import SwiftUI
+import SwiftData
 
 struct SeasonsView: View {
     @EnvironmentObject var settingsManager: SettingsManager
-    @State private var selectedAnimal = Animal.mockAnimals[0]
+    @EnvironmentObject var animalsVM: AnimalsViewModel
+    @State private var selectedAnimal = Animal.mockAnimals.first!
     @State private var showingAnimalSelection = false
     
     var body: some View {
@@ -57,6 +59,11 @@ struct SeasonsView: View {
             .background(settingsManager.selectedTheme.backgroundGradient)
             .sheet(isPresented: $showingAnimalSelection) {
                 AnimalSelectionSheet(selectedAnimal: $selectedAnimal)
+            }
+            .onAppear {
+                if let first = animalsVM.animals.first {
+                    selectedAnimal = first
+                }
             }
         }
     }
@@ -258,11 +265,12 @@ struct DifficultyBadge: View {
 struct AnimalSelectionSheet: View {
     @Binding var selectedAnimal: Animal
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var animalsVM: AnimalsViewModel
     
     var body: some View {
         NavigationStack {
             LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 16) {
-                ForEach(Animal.mockAnimals) { animal in
+                ForEach(animalsVM.animals) { animal in
                     AnimalSelectionCard(
                         animal: animal,
                         isSelected: animal.id == selectedAnimal.id

--- a/HuntersCompanion/ViewModels/AchievementsViewModel.swift
+++ b/HuntersCompanion/ViewModels/AchievementsViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class AchievementsViewModel: ObservableObject {
+    @Published private(set) var achievements: [AchievementEntity] = []
+    private let context: ModelContext
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        fetch()
+    }
+
+    func fetch() {
+        let descriptor = FetchDescriptor<AchievementEntity>()
+        if let result = try? context.fetch(descriptor) {
+            achievements = result
+        }
+    }
+
+    func unlock(_ achievement: AchievementEntity) {
+        achievement.unlocked = true
+        try? context.save()
+        fetch()
+    }
+}

--- a/HuntersCompanion/ViewModels/AnimalsViewModel.swift
+++ b/HuntersCompanion/ViewModels/AnimalsViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class AnimalsViewModel: ObservableObject {
+    @Published private(set) var animals: [Animal] = []
+    private let context: ModelContext
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        fetchAnimals()
+    }
+
+    func fetchAnimals() {
+        let descriptor = FetchDescriptor<Animal>()
+        if let result = try? context.fetch(descriptor) {
+            animals = result
+        }
+    }
+}

--- a/HuntersCompanion/ViewModels/BaitsViewModel.swift
+++ b/HuntersCompanion/ViewModels/BaitsViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class BaitsViewModel: ObservableObject {
+    @Published private(set) var baits: [Bait] = []
+    private let context: ModelContext
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        fetchBaits()
+    }
+
+    func fetchBaits() {
+        let descriptor = FetchDescriptor<Bait>()
+        if let result = try? context.fetch(descriptor) {
+            baits = result
+        }
+    }
+}

--- a/HuntersCompanion/ViewModels/LocationsViewModel.swift
+++ b/HuntersCompanion/ViewModels/LocationsViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class LocationsViewModel: ObservableObject {
+    @Published private(set) var locations: [LocationEntity] = []
+    private let context: ModelContext
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        fetch()
+    }
+
+    func fetch() {
+        let descriptor = FetchDescriptor<LocationEntity>()
+        if let result = try? context.fetch(descriptor) {
+            locations = result
+        }
+    }
+
+    func add(name: String, latitude: Double, longitude: Double) {
+        let loc = LocationEntity(name: name, latitude: latitude, longitude: longitude)
+        context.insert(loc)
+        try? context.save()
+        fetch()
+    }
+}

--- a/HuntersCompanion/ViewModels/ProgressViewModel.swift
+++ b/HuntersCompanion/ViewModels/ProgressViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class ProgressViewModel: ObservableObject {
+    @Published var completedPracticeIds: Set<UUID> = []
+    private let context: ModelContext
+    private var progress: UserProgressEntity?
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        load()
+    }
+
+    func load() {
+        let descriptor = FetchDescriptor<UserProgressEntity>()
+        if let progress = try? context.fetch(descriptor).first {
+            self.progress = progress
+            completedPracticeIds = Set(progress.completedPracticeIds)
+        } else {
+            let new = UserProgressEntity()
+            context.insert(new)
+            self.progress = new
+            try? context.save()
+        }
+    }
+
+    func togglePractice(id: UUID) {
+        if completedPracticeIds.contains(id) {
+            completedPracticeIds.remove(id)
+        } else {
+            completedPracticeIds.insert(id)
+        }
+        save()
+    }
+
+    func save() {
+        progress?.completedPracticeIds = Array(completedPracticeIds)
+        try? context.save()
+    }
+}

--- a/HuntersCompanion/ViewModels/SettingsViewModel.swift
+++ b/HuntersCompanion/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Combine
+import SwiftData
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published var currentLanguage: AppLanguage = .en
+    @Published var selectedTheme: AppTheme = .nature
+    @Published var largeTextEnabled: Bool = false
+    @Published var highContrastEnabled: Bool = false
+    @Published var hasSeenOnboarding: Bool = false
+
+    private let context: ModelContext
+    private var settings: SettingsEntity?
+
+    init(container: ModelContainer = PersistenceController.shared) {
+        self.context = ModelContext(container)
+        load()
+    }
+
+    func load() {
+        let descriptor = FetchDescriptor<SettingsEntity>()
+        if let entity = try? context.fetch(descriptor).first {
+            settings = entity
+            currentLanguage = AppLanguage(rawValue: entity.language) ?? .en
+            selectedTheme = AppTheme(rawValue: entity.theme) ?? .nature
+            largeTextEnabled = entity.largeText
+            highContrastEnabled = entity.highContrast
+            hasSeenOnboarding = entity.hasSeenOnboarding
+        } else {
+            let entity = SettingsEntity()
+            context.insert(entity)
+            settings = entity
+            try? context.save()
+        }
+    }
+
+    func save() {
+        settings?.language = currentLanguage.rawValue
+        settings?.theme = selectedTheme.rawValue
+        settings?.largeText = largeTextEnabled
+        settings?.highContrast = highContrastEnabled
+        settings?.hasSeenOnboarding = hasSeenOnboarding
+        try? context.save()
+    }
+}


### PR DESCRIPTION
## Summary
- create persistent SwiftData models
- refactor struct models into `@Model` classes
- implement Combine-based view models
- use persistent storage in settings and trails managers
- hook view models into the main app and views

## Testing
- `swiftc -parse HuntersCompanion/Models.swift`
- `swiftc -parse HuntersCompanion/OnboardingView.swift`
- `swiftc -parse HuntersCompanion/OtherViews.swift`
- `swiftc -parse HuntersCompanion/SeasonsView.swift`
- `swiftc -parse HuntersCompanion/HunterCompanionApp.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6884ff7ff6588320b91e5a7d6e3062fe